### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,6 @@
 name: lint
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/h5p-go/security/code-scanning/1](https://github.com/grokify/h5p-go/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow, and set `contents: read`, ensuring jobs restrict the GITHUB_TOKEN to only what is required. Since this workflow only checks out code and runs linter actions, it only needs `contents: read`. The recommended way is to place the `permissions` block at the top-level (just after the `name` and before `on` or `jobs`), so it applies to all jobs by default. No additional methods, imports, or configuration are needed - just update the YAML file and insert the block as described.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
