### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/h5p-go/security/code-scanning/2](https://github.com/grokify/h5p-go/security/code-scanning/2)

To fix this problem, we should add an explicit `permissions` block to the workflow, limiting GITHUB_TOKEN's permissions to only those necessary to run the workflow. Based on the shown steps (checking out code and running tests), the workflow only needs read access to contents. Therefore, the `permissions` block with `contents: read` should be added. The best place for this is at the top level of the workflow (after the `name:` and before the `on:` block), making it apply to all jobs unless overridden. This change does not alter any job behavior but makes the security configuration explicit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
